### PR TITLE
fzf seems to have been changed to fzf-base

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -244,7 +244,7 @@
 (defun fzf-find-file (&optional directory)
   (interactive)
   (let ((d (fzf/resolve-directory directory)))
-    (fzf
+    (fzf-base
     (lambda (x)
         (let ((f (expand-file-name x d)))
         (when (file-exists-p f)


### PR DESCRIPTION
Not sure if this is only an issue on my machine but in a clean spacemacs install I was getting an error about function fzf not being defined.
Looks like it has changed to fzf-base.